### PR TITLE
add tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,5 @@
+[tox]
+envlist = py2.6,py2.7,py3.4,py3.5,py3.6
+
+[testenv]
+commands=python setup.py test


### PR DESCRIPTION
This commit adds simple `tox.ini` for easier testing across different Python versions (2.6, 2.7, 3.4, 3.5, 3.6).