### PR TITLE
Add support for python >= 3.6 fstrings

### DIFF
--- a/test_unify.py
+++ b/test_unify.py
@@ -62,6 +62,47 @@ class TestUnits(unittest.TestCase):
                                            preferred_quote="'"))
 
 
+class TestUnitsWithFstrings(unittest.TestCase):
+    """ Tests for python >= 3.6 fstring handling."""
+
+    def test_unify_quotes(self):
+        self.assertEqual("f'foo'",
+                         unify.unify_quotes('f"foo"',
+                                            preferred_quote="'"))
+
+        self.assertEqual('f"foo"',
+                         unify.unify_quotes('f"foo"',
+                                            preferred_quote='"'))
+
+        self.assertEqual('f"foo"',
+                         unify.unify_quotes("f'foo'",
+                                            preferred_quote='"'))
+
+    def test_unify_quotes_should_avoid_some_cases(self):
+        self.assertEqual('''f"foo's"''',
+                         unify.unify_quotes('''f"foo's"''',
+                                            preferred_quote="'"))
+
+        self.assertEqual('''f"""foo"""''',
+                         unify.unify_quotes('''f"""foo"""''',
+                                            preferred_quote="'"))
+
+    def test_format_code(self):
+        self.assertEqual("x = f'abc' \\\nf'next'\n",
+                         unify.format_code('x = f"abc" \\\nf"next"\n',
+                                           preferred_quote="'"))
+
+    def test_format_code_with_backslash_in_comment(self):
+        self.assertEqual("x = f'abc' #\\\nf'next'\n",
+                         unify.format_code('x = f"abc" #\\\nf"next"\n',
+                                           preferred_quote="'"))
+
+    def test_format_code_with_syntax_error(self):
+        self.assertEqual('foo(f"abc"\n',
+                         unify.format_code('foo(f"abc"\n',
+                                           preferred_quote="'"))
+
+
 class TestSystem(unittest.TestCase):
 
     def test_diff(self):

--- a/unify.py
+++ b/unify.py
@@ -82,7 +82,8 @@ def unify_quotes(token_string, preferred_quote):
     bad_quote = {'"': "'",
                  "'": '"'}[preferred_quote]
 
-    if not token_string.startswith(bad_quote):
+    if not (token_string.startswith(bad_quote)
+            or token_string.startswith('f' + bad_quote)):
         return token_string
 
     if token_string.count(bad_quote) != 2:
@@ -90,10 +91,14 @@ def unify_quotes(token_string, preferred_quote):
 
     if preferred_quote in token_string:
         return token_string
+    is_fstring = token_string.startswith('f' + bad_quote)
 
-    assert token_string.startswith(bad_quote)
+    assert token_string.startswith(bad_quote) or is_fstring
     assert token_string.endswith(bad_quote)
     assert len(token_string) >= 2
+
+    if is_fstring:
+        return 'f' + preferred_quote + token_string[2:-1] + preferred_quote
 
     return preferred_quote + token_string[1:-1] + preferred_quote
 


### PR DESCRIPTION
Added support for unifying Python 3.6 fstrings (eg. `f"foo{bar}").

Actually, because of the way fstrings are classified by `tokenize`, they are handled correctly if `unify` in version 0.3 is ran in Python <= 3.5. In these Python versions `f"foo{bar}"` is being split into two tokens: 
```python
[{'token_string': 'f', 'token_type': 1},
 {'token_string': '"foo{bar}"', 'token_type': 3}]
 ```

 However, ran in Python 3.6 `tokenize` handles it differently:
 ```python
[{'token_string': 'f"foo{bar}"', 'token_type': 3}]
 ```

Example of unify v0.3 runs:
```python
# dummy.py
string_ = "asdf"
fstring = f"{string_}"
```
```
(python_3.5) $ unify --check-only dummy.py
--- before/dummy.py
+++ after/dummy.py
@@ -1,2 +1,2 @@
-string_ = "foo"
-fstring = f"{string_}"
+string_ = 'foo'
+fstring = f'{string_}'
```
```
(python_3.6) $ unify --check-only dummy.py
--- before/dummy.py
+++ after/dummy.py
@@ -1,2 +1,2 @@
-string_ = "foo"
+string_ = 'foo'
 fstring = f"{string_}"
```

The proposed change keeps behavior consistent between Python versions.