### PR TITLE
Add bytes support python3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ dist/
 htmlcov/
 unify.egg-info/
 untokenize-0.1-py3.3.egg
+.idea/
+.python-version

--- a/test_unify.py
+++ b/test_unify.py
@@ -103,6 +103,47 @@ class TestUnitsWithFstrings(unittest.TestCase):
                                            preferred_quote="'"))
 
 
+class TestUnitsWithByteStrings(unittest.TestCase):
+    """ Tests for python3 byte string handling."""
+
+    def test_unify_quotes(self):
+        self.assertEqual("b'foo'",
+                         unify.unify_quotes('b"foo"',
+                                            preferred_quote="'"))
+
+        self.assertEqual('b"foo"',
+                         unify.unify_quotes('b"foo"',
+                                            preferred_quote='"'))
+
+        self.assertEqual('b"foo"',
+                         unify.unify_quotes("b'foo'",
+                                            preferred_quote='"'))
+
+    def test_unify_quotes_should_avoid_some_cases(self):
+        self.assertEqual('''b"foo's"''',
+                         unify.unify_quotes('''b"foo's"''',
+                                            preferred_quote="'"))
+
+        self.assertEqual('''b"""foo"""''',
+                         unify.unify_quotes('''b"""foo"""''',
+                                            preferred_quote="'"))
+
+    def test_format_code(self):
+        self.assertEqual("x = b'abc' \\\nb'next'\n",
+                         unify.format_code('x = b"abc" \\\nb"next"\n',
+                                           preferred_quote="'"))
+
+    def test_format_code_with_backslash_in_comment(self):
+        self.assertEqual("x = b'abc' #\\\nb'next'\n",
+                         unify.format_code('x = b"abc" #\\\nb"next"\n',
+                                           preferred_quote="'"))
+
+    def test_format_code_with_syntax_error(self):
+        self.assertEqual('foo(b"abc"\n',
+                         unify.format_code('foo(b"abc"\n',
+                                           preferred_quote="'"))
+
+
 class TestSystem(unittest.TestCase):
 
     def test_diff(self):

--- a/unify.py
+++ b/unify.py
@@ -83,7 +83,8 @@ def unify_quotes(token_string, preferred_quote):
                  "'": '"'}[preferred_quote]
 
     if not (token_string.startswith(bad_quote)
-            or token_string.startswith('f' + bad_quote)):
+            or token_string.startswith('f' + bad_quote)
+            or token_string.startswith('b' + bad_quote)):
         return token_string
 
     if token_string.count(bad_quote) != 2:
@@ -92,13 +93,16 @@ def unify_quotes(token_string, preferred_quote):
     if preferred_quote in token_string:
         return token_string
     is_fstring = token_string.startswith('f' + bad_quote)
+    is_byte_string = token_string.startswith('b' + bad_quote)
 
-    assert token_string.startswith(bad_quote) or is_fstring
+    assert token_string.startswith(bad_quote) or is_fstring or is_byte_string
     assert token_string.endswith(bad_quote)
     assert len(token_string) >= 2
 
     if is_fstring:
         return 'f' + preferred_quote + token_string[2:-1] + preferred_quote
+    if is_byte_string:
+        return 'b' + preferred_quote + token_string[2:-1] + preferred_quote
 
     return preferred_quote + token_string[1:-1] + preferred_quote
 

--- a/unify.py
+++ b/unify.py
@@ -82,9 +82,14 @@ def unify_quotes(token_string, preferred_quote):
     bad_quote = {'"': "'",
                  "'": '"'}[preferred_quote]
 
-    if not (token_string.startswith(bad_quote)
-            or token_string.startswith('f' + bad_quote)
-            or token_string.startswith('b' + bad_quote)):
+    allowed_starts = {
+        '': bad_quote,
+        'f': 'f' + bad_quote,
+        'b': 'b' + bad_quote
+    }
+
+    if not any(token_string.startswith(start)
+               for start in allowed_starts.values()):
         return token_string
 
     if token_string.count(bad_quote) != 2:
@@ -92,19 +97,17 @@ def unify_quotes(token_string, preferred_quote):
 
     if preferred_quote in token_string:
         return token_string
-    is_fstring = token_string.startswith('f' + bad_quote)
-    is_byte_string = token_string.startswith('b' + bad_quote)
 
-    assert token_string.startswith(bad_quote) or is_fstring or is_byte_string
     assert token_string.endswith(bad_quote)
     assert len(token_string) >= 2
-
-    if is_fstring:
-        return 'f' + preferred_quote + token_string[2:-1] + preferred_quote
-    if is_byte_string:
-        return 'b' + preferred_quote + token_string[2:-1] + preferred_quote
-
-    return preferred_quote + token_string[1:-1] + preferred_quote
+    for prefix, start in allowed_starts.items():
+        if token_string.startswith(start):
+            chars_to_strip_from_front = len(start)
+            return '{prefix}{preferred_quote}{token}{preferred_quote}'.format(
+                prefix=prefix,
+                preferred_quote=preferred_quote,
+                token=token_string[chars_to_strip_from_front:-1]
+            )
 
 
 def open_with_encoding(filename, encoding, mode='r'):


### PR DESCRIPTION
This pull request is analogous to the one implementing fstring handling (#4)  but for byte strings. 

7426f24  adds the support for byte strings in much the same way as it was done for fstrings.

d434f8e changes the way it's handled, allowing for much easier addition of another prefixes (`u"unicode literals from python2"` and `r'raw strings'`). I think it could also make adding command line parameters for including / excluding specific prefixes.