### PR TITLE
include test_unify.py in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include LICENSE
 include README.rst
+include test_unify.py


### PR DESCRIPTION
This file is required by setup.py and should be included in the source distribution.

Furthermore, it would be nice if the lastest PyPi version could be re-released after this fix was applied.